### PR TITLE
Add space after `ObjectProperty` to improve readability of `ValueError` output.

### DIFF
--- a/kivy/properties.pyx
+++ b/kivy/properties.pyx
@@ -748,7 +748,7 @@ cdef class NumericProperty(Property):
             return self.parse_list(obj, x[0], x[1], ps)
         else:
             raise ValueError(
-                '%s.%s has an invalid format (got %r). Consider using ObjectProperty'
+                '%s.%s has an invalid format (got %r). Consider using ObjectProperty '
                 'or use errorhandler to convert to a number' % (
                 obj.__class__.__name__,
                 self.name, x))


### PR DESCRIPTION
Add space after `ObjectProperty` to improve readability of `ValueError` output.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
